### PR TITLE
Downgrade Cake.CMake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 third-party/
 tools/
+!tools/packages.config
 tmp*/
 
 ## Ignore Visual Studio temporary files, build results, and

--- a/build.ps1
+++ b/build.ps1
@@ -150,14 +150,6 @@ if ((Test-Path $PSScriptRoot) -and !(Test-Path $TOOLS_DIR)) {
     New-Item -Path $TOOLS_DIR -Type directory | out-null
 }
 
-# Make sure that packages.config exist.
-if (!(Test-Path $PACKAGES_CONFIG)) {
-    Write-Verbose -Message "Downloading packages.config..."
-    try { (New-Object System.Net.WebClient).DownloadFile("http://cakebuild.net/download/bootstrapper/packages", $PACKAGES_CONFIG) } catch {
-        Throw "Could not download packages.config."
-    }
-}
-
 # Try find NuGet.exe in path if not exists
 if (!(Test-Path $NUGET_EXE)) {
     Write-Verbose -Message "Trying to find nuget.exe in PATH..."

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+    <package id="Cake" version="0.18.0" />
+</packages>


### PR DESCRIPTION
fix Cake.CMake assembly versions dependencies
Cake.CMake forcibly downgraded to version 0.18.0