### PR TITLE
Use 2nd version of Authenticate method

### DIFF
--- a/src/DiadocApi.cpp
+++ b/src/DiadocApi.cpp
@@ -413,7 +413,7 @@ void DiadocApi::Authenticate(const std::wstring& login, const std::wstring& pass
 {
 	WppTraceDebugOut(L"Authenticating by login/password pair...");
 	std::wstringstream wss;
-	wss << L"/Authenticate?login=" << StringHelper::CanonicalizeUrl(login) << L"&password=" << StringHelper::CanonicalizeUrl(password) << std::flush;
+	wss << L"/V2/Authenticate?login=" << StringHelper::CanonicalizeUrl(login) << L"&password=" << StringHelper::CanonicalizeUrl(password) << std::flush;
 	auto response = PerformHttpRequestString(wss.str(), POST);
 	token_ = StringHelper::Utf8ToUtf16(response);
 }
@@ -421,7 +421,7 @@ void DiadocApi::Authenticate(const std::wstring& login, const std::wstring& pass
 void DiadocApi::Authenticate(const Bytes_t& certBytes, bool useLocalMachineStorage)
 {
 	WppTraceDebugOut(L"Authenticating by certBytes...");
-	auto response = PerformHttpRequest(L"/Authenticate", certBytes, POST);
+	auto response = PerformHttpRequest(L"/V2/Authenticate", certBytes, POST);
 	CertSystemStore store(useLocalMachineStorage);
 	auto decryptedResponse = store.Decrypt(response);
 	token_ = CryptHelper::ToBase64(decryptedResponse);


### PR DESCRIPTION
[AuthenticateConfirm](http://api-docs.diadoc.ru/ru/latest/http/AuthenticateConfirm.html) is not implemented in C++ SDK. Thus, I've only changed urls in existing methods.