### PR TITLE
Fix auth v3 by cert. Separate headers with new line

### DIFF
--- a/src/DiadocApi.cpp
+++ b/src/DiadocApi.cpp
@@ -291,7 +291,7 @@ void DiadocApi::SendRequest(HttpRequest& request, const Bytes_t& requestBody, co
 
 	if (contentType != NULL)
 	{
-		headers += L";";
+		headers += L"\r\n";
 		headers += ContentTypeHeader(*contentType);
 	}
 


### PR DESCRIPTION
Аутентификация по сертификату возвращала ошибку 401 Invalid API client id. Заголовки надо разделять переводом строки, а не ";"